### PR TITLE
Part 3

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -18,7 +18,8 @@ class ProductController extends Controller
     public function new(Request $request)
     {
         $validated = $request->validate([
-            'name' => 'required|alpha_dash|unique:products|min:3|max:255',
+            'name' => 'required|alpha_dash|unique:products|min:3|max:64',
+            'description' => 'max:255'
         ]);
 
         Product::create($validated);

--- a/app/Product.php
+++ b/app/Product.php
@@ -16,4 +16,29 @@ class Product extends Model
         'name',
         'description'
     ];
+
+    protected $appends = array('splitDescription');
+
+    /**
+     * Get the product's multiline description split by newlines
+     *
+     * @param  string  $value
+     * @return array   description split by newlines
+     */
+    public function getSplitDescriptionAttribute()
+    {
+        return explode("\r\n", $this->description);
+    }
+
+    /**
+     * Set the product's description.
+     * Replace description with only empty newlines by NULL
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setDescriptionAttribute($value)
+    {
+        $this->attributes['description'] = empty($value) ? NULL : $value;
+    }
 }

--- a/app/Product.php
+++ b/app/Product.php
@@ -14,5 +14,6 @@ class Product extends Model
      */
     protected $fillable = [
         'name',
+        'description'
     ];
 }

--- a/database/migrations/2022_11_19_175756_add_description_to_product.php
+++ b/database/migrations/2022_11_19_175756_add_description_to_product.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDescriptionToProduct extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('description', 255)->nullable()->comment('The product\'s description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -34,6 +34,14 @@
             @foreach ($products as $product)
             <li>
                 <b>{{ $product->name }}</b>
+                @if (!is_null($product->description))
+                    <p>@foreach ($product->splitDescription as $line)
+                        {{ $line }}<br>
+                    @endforeach
+                    </p>
+                @else
+                    <p><em>No description.</em></p>
+                @endif
                 <form action="{{ route('products.delete', $product) }}" method="POST">
                     @csrf
                     @method('DELETE')


### PR DESCRIPTION
This PR contains the new description field of the Product model.
The multiline description entered in the frontend is filtered by replacing only newlines with null. Furthermore, an additional attribute `splitDescription` is added to the model which returns the description split on newlines (for convenience in the frontend).

The new column can be added by running the migration `php artisan migrate`. The description is displayed in the frontend using the additional 

This PR fixes #6.